### PR TITLE
Patched lock method so it works in django-nonrel

### DIFF
--- a/background_task/models.py
+++ b/background_task/models.py
@@ -88,9 +88,10 @@ class Task(models.Model):
     def lock(self, locked_by):
         now = datetime_now()
         unlocked = Task.objects.unlocked(now).filter(pk=self.pk)
-        updated = unlocked.update(locked_by=locked_by, locked_at=now)
-        if updated:
-            return Task.objects.get(pk=self.pk)
+        unlocked.update(locked_by=locked_by, locked_at=now)
+        task = Task.objects.get(pk=self.pk)
+        if task.locked_by == locked_by:
+            return task
         return None
     
     def _extract_error(self, type, err, tb):


### PR DESCRIPTION
I'm using django-background-task with the django-nonrel branch and it seems not to be working because a limitation of django-nonrel itself: when doing model updates, it doesn't return the number of records changed.

Having a look to the code, it seems that this small change should be enough to avoid that problem and have it running in django-nonrel (it supports atomic updates according to the documentation). Efficiency wise it would be running an extra query only when a lock acquisition has failed, and that shouldn't happen that frequently unless you are running many consumers at exactly the same time.
