### PR TITLE
Add shortcut `now` to launch background function right now

### DIFF
--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -183,7 +183,7 @@ class DBTaskRunner(object):
 class TaskProxy(object):
     def __init__(self, name, task_function, schedule, runner):
         self.name = name
-        self.task_function = task_function
+        self.now = self.task_function = task_function
         self.runner = runner
         self.schedule = TaskSchedule.create(schedule)
 


### PR DESCRIPTION
Add ability to launch background task right now as normal function:

```
from background_task import background
@background
def add(x,y):
    return x+y

add(2, 2)      # create a task 
add.now(2, 2)  # launch it right now and got answer 4.
```

Today we can do it using `add.task_function(2,2)` but proposed `now` shortcut is cleaner and simpler.
